### PR TITLE
Προσθήκη επιπλέον yaml αρχείου για χρήση SQLite ως Β.Δ.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ https://drive.google.com/file/d/0B2ACFOVDi2ORWmZjUGNmQTNpVlk/view?usp=sharing
 - Αν χρησιμοποιούμε παλιότερη έκδοση του docker, αντικαθιστούμε το ```docker compose``` με ```docker-compose``` παντού.
 - Λόγω της φύσης του docker, ενδείκνυται εγκατάσταση με τη μέθοδο αυτή *σε σύστημα με λειτουργικό Linux*.
 Φυσικά παίζει και σε Windows με *Docker desktop* (βλ. παραπάνω), αλλά θέλει γερό μηχάνημα και πολύ γερά νεύρα γιατί το docker desktop είναι βαρύ και ασήκωτο!
+- H MySQL είναι η default βάση δεδομένων. Αν επιθυμείτε SQLite, ορίστε ```DB_CONNECTION=sqlite``` μέσα στο ```.env-docker``` προτού ξεκινήσετε την εγκατάσταση
 - Μπορεί να χρειαστεί να ρυθμίσετε permissions στον υπολογιστή σας ```chmod -R 0777 <dirname>``` ώστε να είναι εγγράψιμοι οι φάκελοι ```storage```, ```public```.
 - Αν αλλάξετε ρυθμίσεις σε κάποιο αρχείο ρυθμίσεων στον φάκελο ```config``` μετά την εγκατάσταση, πχ ```imap.php```, θα πρέπει για να έφαρμοστούν οι αλλαγές που κάνατε να ανανεώσετε την cache του config με την εντολή ```docker compose exec app php artisan config:cache```
 

--- a/docker-compose-sqlite.yml
+++ b/docker-compose-sqlite.yml
@@ -1,0 +1,33 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: app
+    restart: unless-stopped
+    volumes:
+      - ./:/var/www/html
+      - ./docker/php/local.ini:/usr/local/etc/php/conf.d/laravel.ini
+    networks:
+      - app-network
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    restart: unless-stopped
+    ports:
+      - ${APP_PORT:-80}:80
+    volumes:
+      - ./docker/nginx/conf.d/:/etc/nginx/conf.d/
+      - ./:/var/www/html
+    depends_on:
+      - app
+    networks:
+      - app-network
+
+
+networks:
+  app-network:
+    driver: bridge

--- a/docker-install.bat
+++ b/docker-install.bat
@@ -1,9 +1,29 @@
+@echo off
+
+REM Prepare .env
 ren .env .env-old
 copy .env-docker .env
 set "pwd=%cd%"
+
+REM Install composer dependencies
 docker run --rm -v %pwd%:/app composer install --no-dev --ignore-platform-req=ext-gd
-docker compose up -d
+
+REM Read .env variables
+for /f "usebackq tokens=1* delims==" %%a in (.env) do (
+  set "%%a=%%b"
+)
+
+REM Check if the database connection is SQLite
+if "%DB_CONNECTION%"=="sqlite" (
+  docker compose -f docker-compose-sqlite.yml up -d 
+) else (
+  docker compose up -d
+)
+
+
 timeout /t 20
+
+REM Prepare Laravel
 docker compose exec app php artisan key:generate
 docker compose exec app php artisan migrate:refresh --seed
 docker compose exec app php artisan config:cache

--- a/docker-install.sh
+++ b/docker-install.sh
@@ -1,9 +1,22 @@
 #!/bin/sh
 mv .env .env-old
 cp .env-docker .env
+
+# install composer dependencies
 docker run --rm -v $(pwd):/app composer install --no-dev --ignore-platform-req=ext-gd
-docker compose up -d
+
+# load variables from .env
+source .env
+# check if sqlite or mysql and start docker with the appropriate yml
+if [[ $DB_CONNECTION == "sqlite" ]]; then
+  docker compose -f docker-compose-sqlite.yml up -d 
+else
+  docker compose up -d
+fi
+
 sleep 20
+
+# prepare laravel
 docker compose exec app php artisan key:generate
 docker compose exec app php artisan migrate:refresh --seed
 docker compose exec app php artisan config:cache


### PR DESCRIPTION
Σε περίπτωση που ο χρήστης επιθυμεί χρήση SQLite, μπορεί:

1. να ορίσει: DB_CONNECTION=sqlite μέσα στο αρχείο .env-docker και 

2. να τρέξει κανονικά ένα από τα docker-install.sh, docker-install.bat 

για να προχωρήσει στην εγκατάσταση με docker